### PR TITLE
Alan porting radio to dinkum

### DIFF
--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -14,13 +14,10 @@
 # TODO
 #   play <station name> should find if provided
 #   add to favorites and play favorite
-import subprocess
-import time
-from typing import Optional, Tuple
+from typing import Tuple
 
 import requests
-from mycroft.messagebus import Message
-from mycroft.skills import AdaptIntent, GuiClear, intent_handler
+from mycroft.skills import GuiClear, intent_handler
 from mycroft.skills.common_play_skill import CommonPlaySkill, CPSMatchLevel
 
 from .RadioStations import RadioStations
@@ -294,7 +291,7 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
             )
  
     @intent_handler("TurnOnRadio.intent")
-    def handle_turnon_intent(self, message):
+    def handle_turnon_intent(self, _):
         if self.current_station is None:
             self.setup_for_play(self.rs.get_next_channel())
         self.play_current()
@@ -354,7 +351,7 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
         """Handle request from Common Play System to start playback."""
         self.handle_play_request()
 
-    def stop(self) -> bool:
+    def stop(self) -> None:
         """Respond to system stop commands."""
         self.now_playing = None
         self.CPS_send_status()


### PR DESCRIPTION
#### Description
Fixes all known issues with porting radio skill to dinkum. 

- Restored functionality of all intent handlers.
- Fixed some GUI issues whereby the theme was not rendering properly.
- Minor cleanup.


#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
You can start this skill in Dinkum by running:

`scripts/run-skill.sh skills/play-radio.mark2`


#### Documentation
Does documentation for this already exist? Are there docstrings on all the public methods you added or modified? Have these been updated?

I did not add docstrings or any comments. Since I am still learning how some of this works and since I didn't add anything, I thought it might be best to leave the docstrings as is for now.