### PR TITLE
Radio Skill - Adding 'vocab' items to intents.

### DIFF
--- a/skills/play-radio.mark2/vocab/en-us/NextChannel.intent
+++ b/skills/play-radio.mark2/vocab/en-us/NextChannel.intent
@@ -1,2 +1,6 @@
 next channel
 channel next
+play next channel
+next genre
+genre next
+play next genre

--- a/skills/play-radio.mark2/vocab/en-us/NextStation.intent
+++ b/skills/play-radio.mark2/vocab/en-us/NextStation.intent
@@ -2,3 +2,5 @@ next station
 radio next
 next radio
 next
+play next station
+play next radio

--- a/skills/play-radio.mark2/vocab/en-us/PreviousChannel.intent
+++ b/skills/play-radio.mark2/vocab/en-us/PreviousChannel.intent
@@ -1,2 +1,12 @@
 previous channel
 channel previous
+play previous channel
+play channel previous
+previous genre
+genre previous
+play previous genre
+play genre previous
+go back genre
+go back channel
+go back one genre
+go back one channel

--- a/skills/play-radio.mark2/vocab/en-us/PreviousStation.intent
+++ b/skills/play-radio.mark2/vocab/en-us/PreviousStation.intent
@@ -2,3 +2,7 @@ previous station
 radio previous
 previous radio
 previous
+play previous station
+play station previous
+go back station
+go back one station


### PR DESCRIPTION
#### Description
Replacing #7 

See https://mycroft.atlassian.net/browse/SKILL-569?atlOrigin=eyJpIjoiMGViYmFiYzk2YjA5NGQxYTlmZjZlZTA3ODQyNGIyNjQiLCJwIjoiaiJ9 for details.

I just added some lines to the EN "vocab" files, including additional phrases for "genre" instead of "channel".

Also added "go back" as an option for "previous".

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
While in radio skill, try saying:
"Play next/previous station/channel/genre."
or
"Go back one station/channel/genre."

Previously if you were watching it you could tell that it was simple retriggering the radio skill and would pick something random because of this.

Now it will use the proper next/previous station/channel/genre handlers and behave more like what you expect.