### PR TITLE
Radio Skill - pick image based on partial genre match

### DIFF
--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -154,6 +154,12 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
                 self.genre_images[self.rs.genre_to_play], "ui/images"
             )
         else:
+            for genre_image_name, genre_image_path in self.genre_images.items():
+                if genre_image_name in self.rs.genre_to_play:
+                    self.img_pth = self.find_resource(
+                        genre_image_path, "ui/images"
+                    )
+        if not self.img_pth:
             self.img_pth = self.find_resource("genre_generic_radio.svg", "ui/images")
 
         channel_info = "%s/%s" % (self.rs.station_index + 1, len(self.rs.stations))


### PR DESCRIPTION
Added logic to pick image based on partial match of genre if full match doesn't work.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

