### PR TITLE
Skill 586 radio errors out on mime type check

### DIFF
--- a/skills/play-radio.mark2/RadioStations.py
+++ b/skills/play-radio.mark2/RadioStations.py
@@ -165,6 +165,7 @@ class RadioStations:
         self.station_index = 0
         self.blacklist = [
             "icecast",
+            "bob.hoerradar.de",
         ]
         self.media_verbs = ["play", "listen", "turn on", "start"]
         self.noise_words = ["on", "to", "the", "music", "station", "channel", "radio"]
@@ -257,7 +258,7 @@ class RadioStations:
             Mime type - defaults to 'audio/mpeg'
         """
         mime = "audio/mpeg"
-        response = requests.Session().head(url, allow_redirects=True)
+        response = requests.Session().head(url, allow_redirects=True, timeout=3)
         if 200 <= response.status_code < 300:
             mime = response.headers["content-type"]
         return mime

--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -208,12 +208,21 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
             tries += 1
             try:
                 stream_uri = self.current_station.get("url_resolved", "")
+                if stream_uri:
+                    self.log.debug(f"Getting mime type for {stream_uri}")
+                else:
+                    self.log.error("No stream uri found!")
                 station_name = self.current_station.get("name", "").replace("\n", "")
+                if station_name:
+                    self.log.debug(f"Getting mime type for {station_name}")
+                else:
+                    self.log.error("No station name found!")
                 self.log.debug(f"Attempting to check mime type: try {tries}")
                 mime = self.rs.find_mime_type(stream_uri)
             except requests.exceptions.RequestException as e:
                 self.log.debug(f"Mime type request failed: {e}")
                 self.rs.get_next_station()
+                self.current_station = self.rs.get_current_station()
         if not mime:
             self.log.error("Unsuccessful mime type checks for 10 different stations, cannot connect.")
 


### PR DESCRIPTION
#### Description
This addresses the underlying problem in a number of tickets. The mime type check is the first time the skill attempts to connect to a new server. It wasn't set up with any kind of error handling or retry mechanism, so it would occasionally fail. I believe pretty much all of the outright failures of this skill that I have seen recently come down to this. Now, if it gets a connection error on mime type check, it goes to the next station and tries again. After ten tries it will error out. 

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [X] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Apart from using the skill a lot, one could temporarily hard code a URI that is incorrectly formatted to see the mechanism in action. This is how I tested it.