### PR TITLE
Fixing both the image problem and removing unnecessary lines that mig…

### DIFF
--- a/skills/play-radio.mark2/RadioStations.py
+++ b/skills/play-radio.mark2/RadioStations.py
@@ -206,7 +206,6 @@ class RadioStations:
             # As of this comment it is "pop".
             self.last_search_terms = self.genre_tags[self.channel_index]
             self.genre_to_play = ""
-            self.get_stations(self.last_search_terms)
             self.original_utterance = ""
 
     def query_server(self, endpoint):
@@ -368,7 +367,6 @@ class RadioStations:
             raise GenreTagNotFound
 
         stations = self._search(self.last_search_terms, limit)
-        LOG.debug("RETURNED FROM _SEARCH: {len(stations})")
         # whack dupes, favor match confidence
         for station in stations:
             if station["name"]:

--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -166,6 +166,7 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
             self.CPS_pause()
 
     def update_radio_theme(self, status):
+        self.img_pth = None
         if self.rs.genre_to_play and self.rs.genre_to_play in self.genre_images.keys():
             self.img_pth = self.find_resource(
                 self.genre_images[self.rs.genre_to_play], "ui/images"


### PR DESCRIPTION
…ht in some circumstances cause problems.

#### Description
I introduced a bug last time I touched the code that decides what image to show. It made it so that if a genre should have a generic image, instead of showing that image it would use the previous non-generic image. That is fixed.

The code was also needlessly running an initial search, which in the current master branch might be responsible for some flakey behavior. That is also removed.

Finally, removed an unneeded log line.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
"Play rock"
"Play talk radio"
*shows generic image rather than the rock one*
