### PR TITLE
Skill 593 weather skill gets confused by c f

### DIFF
--- a/skills/weather.mark2/__init__.py
+++ b/skills/weather.mark2/__init__.py
@@ -86,18 +86,11 @@ class WeatherSkill(MycroftSkill):
         requires weather information but should not go through the intent system
         to get it.
         """
-        system_unit = self.config_core.get("system_unit")
-        temperature_unit_type = None
-        if self.weather_config.temperature_unit == "fahrenheit":
-            temperature_unit_type = "imperial"
-        elif self.weather_config.temperature_unit == "celsius":
-            temperature_unit_type = "metric"
-        else:
-            temperature_unit_type = self.config_core["system_unit"]
+        temperature_unit = self.weather_config.temperature_unit
 
         try:
             weather = self.weather_api.get_weather_for_coordinates(
-                temperature_unit_type,
+                temperature_unit,
                 self.weather_config.latitude,
                 self.weather_config.longitude,
                 self.lang,
@@ -1198,20 +1191,12 @@ class WeatherSkill(MycroftSkill):
         """
         weather = None
         dialog = None
-        self.log.debug(f'System unit: {self.config_core["system_unit"]}')
-        self.log.debug(f"Temperature unit: {self.weather_config.temperature_unit}")
-        temperature_unit_type = None
-        if self.weather_config.temperature_unit == "fahrenheit":
-            temperature_unit_type = "imperial"
-        elif self.weather_config.temperature_unit == "celsius":
-            temperature_unit_type = "metric"
-        else:
-            temperature_unit_type = self.config_core["system_unit"]
+        temperature_unit = self.weather_config.temperature_unit
         if intent_data is not None:
             try:
                 latitude, longitude = self._determine_weather_location(intent_data)
                 weather = self.weather_api.get_weather_for_coordinates(
-                    temperature_unit_type, latitude, longitude, self.lang
+                    temperature_unit, latitude, longitude, self.lang
                 )
                 self.log.debug(f"Data returned: {weather}")
             except HTTPError as api_error:

--- a/skills/weather.mark2/skill/api.py
+++ b/skills/weather.mark2/skill/api.py
@@ -108,7 +108,7 @@ class OpenWeatherMapApi(Api):
         super().__init__(path="owm")
 
     def get_weather_for_coordinates(
-        self, measurement_system: str, latitude: float, longitude: float, lang: str
+        self, temperature_units: str, latitude: float, longitude: float, lang: str
     ) -> WeatherReport:
         """Issue an API call and map the return value into a weather report
 
@@ -117,6 +117,17 @@ class OpenWeatherMapApi(Api):
             latitude: the geologic latitude of the weather location
             longitude: the geologic longitude of the weather location
         """
+        # The api uses 'imperial' and 'metric' for units, but we want
+        # to use 'fahrenheit' and 'celsius' when the unit names are spoken.
+        # To avoid confusion with two attributes having two different
+        # semantically identical (for our purposes) values, the attr
+        # we use outside of this method is 'fahrenheit'/'celsius'. Here
+        # we will translate that to conform with the api.
+        if temperature_units == "fahrenheit":
+            measurement_system = "imperial"
+        else:
+            measurement_system = "metric"
+
         query_parameters = dict(
             exclude="minutely",
             lang=owm_language(lang),
@@ -127,8 +138,6 @@ class OpenWeatherMapApi(Api):
         LOG.debug(f"Parameters: {query_parameters}")
         api_request = dict(path="/onecall", query=query_parameters)
         response = self.request(api_request)
-        LOG.debug(f"Response: {response}")
         local_weather = WeatherReport(response)
-        LOG.debug(f"Weather: {local_weather}")
 
         return local_weather


### PR DESCRIPTION
#### Description
The weather skill was having trouble setting temperature units based on the settings in selene. In some cases it manifested as quite odd behavior such as completely incorrect temperature readings. This was happening because the skill was juggling two different attributes values which were semantically identical (for our purposes). The API wants "metric" or 'imperial', but when the temp is spoken we need 'celsius' or 'fahrenheit'. I made it use only one attribute and added something to the api calling method that simply translates f/c into i/m.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Switch settings on selene, wait a minute.