### PR TITLE
Added 'play the news' to the list of generic news phrases, and moved …

### DIFF
--- a/skills/news.mark2/dialog/en-us/PlayTheNews.list
+++ b/skills/news.mark2/dialog/en-us/PlayTheNews.list
@@ -12,3 +12,4 @@ brief me
 news again
 news briefing
 other news
+play the news

--- a/skills/news.mark2/stations/match.py
+++ b/skills/news.mark2/stations/match.py
@@ -77,11 +77,6 @@ def match_station_from_utterance(skill, utterance):
     match = Match(None, 0.0)
 
     utterance = utterance.lower().strip()
-    # Remove articles like "the" as it matches too well with "other"
-    word_list = utterance.split(" ")
-    if "the" in word_list:
-        word_list.remove("the")
-    utterance = " ".join(word_list)
 
     # If news vocab does exist, provide a minimum default confidence
     default_station = skill.get_default_station()
@@ -92,6 +87,12 @@ def match_station_from_utterance(skill, utterance):
     if utterance in news_phrases:
         LOG.debug("Explicit phrase without specific station detected.")
         return Match(default_station, 1.0)
+
+    # Remove articles like "the" as it matches too well with "other"
+    word_list = utterance.split(" ")
+    if "the" in word_list:
+        word_list.remove("the")
+    utterance = " ".join(word_list)
 
     # Test against each station to find the best match.
     news_keyword = skill.translate("OnlyNews").lower()


### PR DESCRIPTION
…the 'the' filter so it doesn't interfere.

#### Description
See [here](https://mycroft.atlassian.net/browse/SKILL-596) for details. 

The problem was that the skill erroneously thought that "play the news" was an attempt to name a particular news station to play. When it found no match, it ended up giving the same (high) confidence to all stations and for some reason settling on BBC.

I will enter a ticket to reevaluate the confidence scoring behavior so that it can deal gracefully with cases where there is no good match.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Say "Play the news" and observe that it plays whatever you have set as your default station.