### PR TITLE
Removed nonworking stations and fixed generic image.

### DIFF
--- a/skills/news.mark2/settingsmeta.json
+++ b/skills/news.mark2/settingsmeta.json
@@ -12,7 +12,7 @@
                         "name": "station",
                         "type": "select",
                         "label": "Options",
-                        "options": "Other URL (please define below)|not_set;AP Hourly Radio News|AP;[AU] ABC News|ABC;[CA] CBC|CBC;[BE] VRT Nieuws|VRT;[DE] DLF|DLF;[DE] WDR|WDR;[ES] RNE National Spanish Radio|RNE;[FI] YLE|YLE;[NL] NOS Journaal|NOS;[PT] RDP Africa|RDP;[PT] TSF|TSF;[SE] Ekot|Ekot;[UK] BBC News|BBC;[US] FOX News|FOX;[US] Georgia Public Radio|GPB;[US] NPR|NPR;[US] PBS NewsHour Daily|PBS",
+                        "options": "Other URL (please define below)|not_set;AP Hourly Radio News|AP;[CA] CBC|CBC;[BE] VRT Nieuws|VRT;[DE] DLF|DLF;[DE] WDR|WDR;[ES] RNE National Spanish Radio|RNE;[FI] YLE|YLE;[PT] RDP Africa|RDP;[PT] TSF|TSF;[UK] BBC News|BBC;[US] FOX News|FOX;[US] NPR|NPR;[US] PBS NewsHour Daily|PBS",
                         "value": "not_set"
                     },
                     {

--- a/skills/news.mark2/stations/station.py
+++ b/skills/news.mark2/stations/station.py
@@ -52,9 +52,9 @@ class BaseStation(ABC):
         Note that this currently traverses the path from this file and may
         break if this is moved in the file hierarchy.
         """
-        if self.image_file is None:
-            return None
         skill_path = Path(__file__).parent.parent.absolute()
+        if self.image_file is None:
+            return Path(skill_path, "images", "generic.png")
         file_path = Path(skill_path, "images", self.image_file)
         if not file_path.exists():
             LOG.warning(f"{self.image_file} could not be found, using default image")
@@ -181,7 +181,7 @@ def create_custom_station(station_url):
 # They can be added to the list of country defaults below.
 
 stations = dict(
-    ABC=FetcherStation("ABC", "ABC News Australia", get_abc_url, "ABC.png", "#4B555C"),
+    # ABC=FetcherStation("ABC", "ABC News Australia", get_abc_url, "ABC.png", "#4B555C"),
     AP=RSSStation(
         "AP",
         "AP Hourly Radio News",
@@ -209,9 +209,9 @@ stations = dict(
         "https://www.deutschlandfunk.de/podcast-nachrichten.1257.de.podcast.xml",
         "DLF.png",
     ),
-    Ekot=RSSStation(
-        "Ekot", "Ekot", "https://api.sr.se/api/rss/pod/3795", "Ekot.png", "#0065BD"
-    ),
+    # Ekot=RSSStation(
+    #     "Ekot", "Ekot", "https://api.sr.se/api/rss/pod/3795", "Ekot.png", "#0065BD"
+    # ),
     FOX=RSSStation(
         "FOX",
         "Fox News",
@@ -220,7 +220,7 @@ stations = dict(
         "#22438D",
     ),
     FT=FetcherStation("FT", "Financial Times", get_ft_url, "FT.png", "#ffcc99"),
-    GPB=FetcherStation("GPB", "Georgia Public Radio", get_gpb_url, None),
+    # GPB=FetcherStation("GPB", "Georgia Public Radio", get_gpb_url, None),
     NPR=RSSStation(
         "NPR",
         "NPR News Now",
@@ -273,14 +273,14 @@ stations = dict(
 
 country_defaults = dict(
     AT="OE3",
-    AU="ABC",
+    # AU="ABC",
     BE="VRT",
     CA="CBC",
     DE="DLF",
     ES="RNE",
     FI="YLE",
     PT="TSF",
-    SE="Ekot",
+    # SE="Ekot",
     UK="BBC",
     US="NPR",
 )


### PR DESCRIPTION
#### Description
ABC and a couple other stations had broken links. In each case I could not find a true "Headlines" style URI so I removed them from the settings and other lists in the skill. The news skill was also not displaying the generic news image in cases where a custom image is not provided. That has been fixed too.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements
