### PR TITLE
'Play music' now defaults to jukebox unless no local music, then radio

### DIFF
--- a/skills/play-music.mark2/__init__.py
+++ b/skills/play-music.mark2/__init__.py
@@ -191,7 +191,15 @@ class LocalMusicSkill(CommonPlaySkill):
             self._mpd_playlist = list(self.mpd_client.search(phrase))
             self.log.debug("Result: %s", self._mpd_playlist)
             if self._mpd_playlist:
+                # We have a match with a particular thing in our library.
                 result = (phrase, CPSMatchLevel.EXACT, {})
+            else:
+                # We have no specific match, but if we have any music at all
+                # we want to return a GENERIC match to CPS.
+                self._mpd_playlist = list(self.mpd_client.random_play())
+                self.log.debug("Generic result: %s", self._mpd_playlist)
+                if self._mpd_playlist:
+                    result = (phrase, CPSMatchLevel.GENERIC, {})
         except Exception:
             self.log.exception("Error searching local music with MPD")
 

--- a/skills/play-music.mark2/locale/en-us/Music.voc
+++ b/skills/play-music.mark2/locale/en-us/Music.voc
@@ -1,3 +1,2 @@
-music
 song
 jukebox

--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -430,8 +430,26 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
         tags = []
         confidence = 0.0
         stream_uri = ""
-        if self.current_station:
-            match_level = CPSMatchLevel.EXACT
+        
+        # "Play music" is a special case, an intent clash.
+        # In order to allow local music to have preference over
+        # the radio in cases where local music is present (handled
+        # in the play-music or "jukebox" skill), in such cases we
+        # want to return a lower confidence even though we have
+        # selected a genre to play.
+        # TODO: The radio skill should be refactored so we can 
+        # do this more reasonably. It should keep track of the difference
+        # between defaulting to a genre and matching one, and set the 
+        # match level directly without having to check the particular
+        # phrases here. This is only intended as a first step to test that
+        # this will work.
+        if self.current_station and (phrase == "play music" or phrase == "play some music"):
+            match_level = CPSMatchLevel.GENERIC
+            tags = self.current_station.get("tags", [])
+            confidence = self.current_station.get("confidence", 0.0)
+            stream_uri = self.current_station.get("url_resolved", "")
+        elif self.current_station:
+            match_level = CPSMatchLevel.GENERIC
             tags = self.current_station.get("tags", [])
             confidence = self.current_station.get("confidence", 0.0)
             stream_uri = self.current_station.get("url_resolved", "")

--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -430,7 +430,7 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
         tags = []
         confidence = 0.0
         stream_uri = ""
-        
+
         # "Play music" is a special case, an intent clash.
         # In order to allow local music to have preference over
         # the radio in cases where local music is present (handled
@@ -443,7 +443,8 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
         # match level directly without having to check the particular
         # phrases here. This is only intended as a first step to test that
         # this will work.
-        if self.current_station and (phrase == "play music" or phrase == "play some music"):
+        self.log.debug(f"Current station: {self.current_station}")
+        if self.current_station and phrase == "music":
             self.log.debug("Generic command.")
             self.log.debug(f"Current station: {self.current_station}")
             match_level = CPSMatchLevel.GENERIC
@@ -451,7 +452,7 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
             confidence = self.current_station.get("confidence", 0.0)
             stream_uri = self.current_station.get("url_resolved", "")
         elif self.current_station:
-            match_level = CPSMatchLevel.GENERIC
+            match_level = CPSMatchLevel.EXACT
             tags = self.current_station.get("tags", [])
             confidence = self.current_station.get("confidence", 0.0)
             stream_uri = self.current_station.get("url_resolved", "")
@@ -481,6 +482,7 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
             "tags": tags,
         }
         self.log.error(f"Confidence: {confidence}")
+        self.log.debug(f"Returning: {self.station_name} {match_level} {skill_data}")
         return self.station_name, match_level, skill_data
 
     def CPS_start(self, _, data):

--- a/skills/play-radio.mark2/__init__.py
+++ b/skills/play-radio.mark2/__init__.py
@@ -444,6 +444,8 @@ class RadioFreeMycroftSkill(CommonPlaySkill):
         # phrases here. This is only intended as a first step to test that
         # this will work.
         if self.current_station and (phrase == "play music" or phrase == "play some music"):
+            self.log.debug("Generic command.")
+            self.log.debug(f"Current station: {self.current_station}")
             match_level = CPSMatchLevel.GENERIC
             tags = self.current_station.get("tags", [])
             confidence = self.current_station.get("confidence", 0.0)

--- a/skills/play.mark2/__init__.py
+++ b/skills/play.mark2/__init__.py
@@ -99,7 +99,7 @@ class PlaybackControlSkill(MycroftSkill):
         self.phrase = message.data["Phrase"]
         self.schedule_event(
             self._play_query_timeout,
-            5,
+            10,
             data={
                 "phrase": self.phrase,
                 "mycroft_session_id": self._mycroft_session_id,


### PR DESCRIPTION
#### Description
https://mycroft.atlassian.net/browse/SKILL-639?atlOrigin=eyJpIjoiMWY2MGFkOGJkMmY3NGFjZDk5OGZlOWEwMDRjNDExOTAiLCJwIjoiaiJ9

#### Type of PR

- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
With no local music:
"Play music" -> radio
With local music:
"Play music" -> jukebox

* Note: There may still be issues with the jukebox skill being brittle and not always working. These tests have been carried out in a situation in which jukebox is already tested and known to be working.

