### PR TITLE
Allow Mark II to start up if Selene pairing fails

### DIFF
--- a/services/enclosure/service/connect_check.py
+++ b/services/enclosure/service/connect_check.py
@@ -481,9 +481,18 @@ class ConnectCheck(MycroftSkill):
                 )
             )
         elif server_state == Authentication.SERVER_UNAVAILABLE:
-            # Show failure page and retry
-            self.log.warning("Server was unavailable. Retrying...")
-            self._fail_and_restart()
+            if self.config["enclosure"]["insist_on_selene_pair"]:
+                # Show failure page and retry
+                self.log.warning("Server was unavailable. Retrying...")
+                self._fail_and_restart()
+            else:
+                # Since we are preparing for a post-selene future, we will want
+                # instead to allow Mycroft to skip the rest of the pairing setup
+                # in cases where the selene server is not available.
+                # Call it done.
+                self._state = State.DONE
+                self.bus.emit(Message("server-connect.startup-finished"))
+                self.bus.emit(self.end_session(gui_clear=GuiClear.NEVER))
         else:
             # Paired already, continue with pantacor sync
             self._state = State.SYNC_PANTACOR

--- a/shared/mycroft/configuration/mycroft.conf
+++ b/shared/mycroft/configuration/mycroft.conf
@@ -233,7 +233,7 @@
     "awconnect_socket_path": "/awconnect/tmp/mycroft_socket",
 
     // Whether to insist on pairing to Selene. If False, will give up on failure
-    "insist_on_selene_pair": False
+    "insist_on_selene_pair": false
   },
 
   // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"

--- a/shared/mycroft/configuration/mycroft.conf
+++ b/shared/mycroft/configuration/mycroft.conf
@@ -230,7 +230,10 @@
     ],
 
     // Path to Unix domain socket for awconnect (hotspot) server
-    "awconnect_socket_path": "/awconnect/tmp/mycroft_socket"
+    "awconnect_socket_path": "/awconnect/tmp/mycroft_socket",
+
+    // Whether to insist on pairing to Selene. If False, will give up on failure
+    "insist_on_selene_pair": False
   },
 
   // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"


### PR DESCRIPTION
#### Description
Added config switch that allows Mycroft to start up anyway if selene isn't there or repeatedly rejects pairing info.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Mangle the url on line 91 of `shared/mycroft/configuration/mycroft.conf`, among other ways.